### PR TITLE
Variable mismatch in keypressHandler

### DIFF
--- a/js/labclock.js
+++ b/js/labclock.js
@@ -157,7 +157,7 @@ var labclock = {
   keypressHandler: function(e) {
     var keyChar;
     if (!document.all) { //Not IE
-      keyChar = event.which;
+      keyChar = e.which;
     } else { //IE
       keyChar = window.event.keyCode;
     }


### PR DESCRIPTION
keypressHandler is passed an event `e`, but refers to it as `event`. This bug only affected non-Internet Explorer browsers.
